### PR TITLE
Fix no-invalid-define rule affecting other rules

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -260,7 +260,7 @@ function isValidDefine(node) {
     // Named modules start with a string literal, if present, we can remove
     // it to continue testing the rest of the arguments
     if (isStringLiteral(args[0])) {
-        args.shift();
+        args = args.slice(1);
     }
 
     return args.length === 1 && (isObjectExpr(args[0]) || isFunctionExpr(args[0])) ||


### PR DESCRIPTION
When the `no-invalid-define` rule is enabled, it can mutate the arguments array. This results in `no-named-define` not producing any warnings when `no-invalid-define` is enabled and could affect other rules.
