### PR TITLE
Fix: enforce-define will warn on any non-ExpressionStatement (fixes #37)

### DIFF
--- a/lib/rules/enforce-define.js
+++ b/lib/rules/enforce-define.js
@@ -65,7 +65,7 @@ module.exports = function (context) {
             for (i = 0, length = node.body.length; i < length; i += 1) {
                 child = node.body[i];
 
-                if (isExpressionStatement(child) && !util.isDefineCall(child.expression)) {
+                if (!(isExpressionStatement(child) && util.isDefineCall(child.expression))) {
                     context.report(node, MESSAGE);
                     break;
                 }

--- a/tests/fixtures/UNWRAPPED_FILE_NO_EXPRESSIONSTATEMENT
+++ b/tests/fixtures/UNWRAPPED_FILE_NO_EXPRESSIONSTATEMENT
@@ -1,0 +1,5 @@
+var foo = 'foo';
+
+function bar() {
+    return foo;
+}

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -131,5 +131,6 @@ function loadFixture(path) {
     "./BAD_REQUIREJS_STRING_DEP",
     "./BAD_REQUIRE_INVALID_CALLBACK",
     "./BAD_REQUIRE_INVALID_ERRBACK",
-    "./UNWRAPPED_FILE"
+    "./UNWRAPPED_FILE",
+    "./UNWRAPPED_FILE_NO_EXPRESSIONSTATEMENT"
 ].forEach(loadFixture);

--- a/tests/lib/rules/enforce-define.js
+++ b/tests/lib/rules/enforce-define.js
@@ -98,6 +98,10 @@ ruleTester.run("enforce-define", rule, {
             errors: [ERROR]
         },
         {
+            code: fixtures.UNWRAPPED_FILE_NO_EXPRESSIONSTATEMENT,
+            errors: [ERROR]
+        },
+        {
             code: fixtures.NON_WRAPPED_EXPORTS,
             errors: [ERROR]
         },


### PR DESCRIPTION
Fixes #37.

I couldn't run the makefile without making some tweaks (I'm on Windows and it was using Linux-like shell syntax), so please do let me know if this PR actually has problems that I'm not aware of. Thanks!
