### PR TITLE
Update: no-multiple-define checks CallExpression only (fixes #42)

### DIFF
--- a/lib/rules/no-multiple-define.js
+++ b/lib/rules/no-multiple-define.js
@@ -6,34 +6,32 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var util = require("../util");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function (context) {
 
-    var MESSAGE = "Multiple `define` calls in a single file are not permitted";
+    var MESSAGE = "Multiple `define` calls in a single file are not permitted",
+        defineCalls = 0;
 
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
 
     return {
-        "Program": function (node) {
-            var defineCount = 0,
-                token,
-                length,
-                i;
+        "CallExpression": function (node) {
+            if (util.isDefineCall(node)) {
+                ++defineCalls;
 
-            for (i = 0, length = node.tokens.length; i < length; i += 1) {
-                token = node.tokens[i];
-
-                if (token.type === "Identifier" && token.value === "define") {
-                    defineCount += 1;
+                if (defineCalls > 1) {
+                    context.report(node, MESSAGE);
                 }
-            }
-
-            if (defineCount > 1) {
-                context.report(node, MESSAGE);
             }
         }
     };

--- a/tests/fixtures/MULTIPLE_DEFINE_ONE_CALL
+++ b/tests/fixtures/MULTIPLE_DEFINE_ONE_CALL
@@ -1,0 +1,5 @@
+if (typeof define === "function") {
+    define(function () {
+        return { foo: 'bar' };
+    });
+}

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -132,5 +132,8 @@ function loadFixture(path) {
     "./BAD_REQUIRE_INVALID_CALLBACK",
     "./BAD_REQUIRE_INVALID_ERRBACK",
     "./UNWRAPPED_FILE",
-    "./UNWRAPPED_FILE_NO_EXPRESSIONSTATEMENT"
+    "./UNWRAPPED_FILE_NO_EXPRESSIONSTATEMENT",
+
+    // Edge cases that are valid
+    "./MULTIPLE_DEFINE_ONE_CALL"
 ].forEach(loadFixture);

--- a/tests/lib/rules/no-multiple-define.js
+++ b/tests/lib/rules/no-multiple-define.js
@@ -18,11 +18,6 @@ var RuleTester = require("eslint").RuleTester,
 // Tests
 //------------------------------------------------------------------------------
 
-var ERROR = {
-    message: "Multiple `define` calls in a single file are not permitted",
-    type: "Program"
-};
-
 var ruleTester = new RuleTester();
 
 ruleTester.run("no-multiple-define", rule, {
@@ -36,11 +31,20 @@ ruleTester.run("no-multiple-define", rule, {
         fixtures.AMD_DEFINE,
         fixtures.AMD_EMPTY_DEFINE,
         fixtures.NAMED_AMD_DEFINE,
-        fixtures.NAMED_AMD_EMPTY_DEFINE
+        fixtures.NAMED_AMD_EMPTY_DEFINE,
+        fixtures.MULTIPLE_DEFINE_ONE_CALL
     ],
 
     invalid: [
-        { code: fixtures.MULTIPLE_DEFINE, errors: [ERROR] }
+        {
+            code: fixtures.MULTIPLE_DEFINE,
+            errors: [{
+                message: "Multiple `define` calls in a single file are not permitted",
+                type: "CallExpression",
+                line: 3,
+                column: 1
+            }]
+        }
     ]
 
 });


### PR DESCRIPTION
Also added a new test case where `define` appears multiple times but is only in a `CallExpression` once. This test case results in an error being reported with current master, but is valid with my code. If you consider that a breaking change rather than a bugfix, let me know and I can tag this as a breaking change.
