### PR TITLE
Build: Added files array to package.json (fixes #40)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "description": "Enforce code conventions for RequireJS modules with ESLint",
   "homepage": "https://github.com/cvisco/eslint-plugin-requirejs",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "lib"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/cvisco/eslint-plugin-requirejs.git"


### PR DESCRIPTION
This approach uses the "files" array to only include absolutely necessary things.

The other approach is to create an `.npmignore` file to create a blacklist, which has slightly less risk of releases containing new files not having been explicitly included. Let me know if you would prefer I go that route instead.
