### PR TITLE
New: Fixer for one-dependency-per-line rule (fixes #51).

### DIFF
--- a/lib/rules/one-dependency-per-line.js
+++ b/lib/rules/one-dependency-per-line.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 
 var uniq = require("lodash.uniq");
+var repeat = require("lodash.repeat");
 var isDefineCall = require("../util").isDefineCall;
 var isRequireCall = require("../util").isRequireCall;
 
@@ -30,6 +31,8 @@ module.exports = function (context) {
         paths: "paths" in options ? options.paths : "always",
         names: "names" in options ? options.names : "always"
     };
+
+    var sourceCode = context.getSourceCode();
 
     //--------------------------------------------------------------------------
     // Helpers
@@ -77,6 +80,59 @@ module.exports = function (context) {
         return settings[setting] === "never";
     }
 
+    function getFileIndentationLevel(args) {
+        var functionLine = lineNum(args[1]);
+        var firstStatementLine = lineNum(args[1].body.body[0]);
+
+        if (functionLine !== firstStatementLine) {
+            return args[1].body.body[0].loc.start.column;
+        }
+        return 0;
+    }
+
+    function getPathsFixer(args) {
+        return function (fixer) {
+            var indentLevel = isFunctionExpr(args[1]) ? getFileIndentationLevel(args) : 0;
+            var replacerText = "";
+
+            var pathsNode = args[0];
+
+            var paths = pathsNode.elements;
+            var formattedPaths = "";
+
+            paths.map(function (path) {
+                formattedPaths += repeat(" ", indentLevel) + path.raw + ",\n";
+            });
+
+            formattedPaths = formattedPaths.slice(0, -2);
+            replacerText = "[\n" + formattedPaths + "\n]";
+
+            return fixer.replaceTextRange(pathsNode.range, replacerText);
+        };
+    }
+
+    function getNamesFixer(args) {
+        return function (fixer) {
+            var indentLevel = isFunctionExpr(args[1]) ? getFileIndentationLevel(args) : 0;
+            var replacerText = "";
+
+            var namesNode = args[1];
+
+            var names = namesNode.params;
+            var formattedNames = "";
+
+            names.map(function (name) {
+                formattedNames += repeat(" ", indentLevel) + name.name + ",\n";
+            });
+
+            formattedNames = formattedNames.slice(0, -2);
+            replacerText += "function (\n" + formattedNames + "\n)";
+            replacerText += " " + sourceCode.getText(namesNode.body);
+
+            return fixer.replaceTextRange(namesNode.range, replacerText);
+        };
+    }
+
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
@@ -111,18 +167,18 @@ module.exports = function (context) {
                 names = args[1].params;
             }
 
-            paths = paths.map(lineNum);
-            names = names.map(lineNum);
+            var pathsLineNums = paths.map(lineNum);
+            var namesLineNums = names.map(lineNum);
 
-            if (isAlways("paths", paths) && hasDuplicateValues(paths)) {
-                context.report(node, ALWAYS_PATHS_MESSAGE);
-            } else if (isNever("paths") && hasMultipleValues(paths)) {
+            if (isAlways("paths", pathsLineNums) && hasDuplicateValues(pathsLineNums)) {
+                context.report({node: node, message: ALWAYS_PATHS_MESSAGE, fix: getPathsFixer(args, pathsLineNums)});
+            } else if (isNever("paths") && hasMultipleValues(pathsLineNums)) {
                 context.report(node, NEVER_PATHS_MESSAGE);
             }
 
-            if (isAlways("names", names) && hasDuplicateValues(names)) {
-                context.report(node, ALWAYS_NAMES_MESSAGE);
-            } else if (isNever("names") && hasMultipleValues(names)) {
+            if (isAlways("names", namesLineNums) && hasDuplicateValues(namesLineNums)) {
+                context.report({node: node, message: ALWAYS_NAMES_MESSAGE, fix: getNamesFixer(args, namesLineNums)});
+            } else if (isNever("names") && hasMultipleValues(namesLineNums)) {
                 context.report(node, NEVER_NAMES_MESSAGE);
             }
 

--- a/package.json
+++ b/package.json
@@ -31,12 +31,13 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "lodash.uniq": "3.2.2"
+    "lodash.uniq": "3.2.2",
+    "lodash.repeat": "3.0.1"
   },
   "devDependencies": {
     "coveralls": "2.11.3",
     "dateformat": "1.0.11",
-    "eslint": "1.1.0",
+    "eslint": "1.9.0",
     "istanbul": "0.3.17",
     "mocha": "2.2.5",
     "semver": "5.0.1",
@@ -44,7 +45,7 @@
     "shelljs-nodecli": "0.1.1"
   },
   "peerDependencies": {
-    "eslint": ">=0.9.0"
+    "eslint": ">=1.4.0"
   },
   "scripts": {
     "test": "node makefile.js test",

--- a/tests/fixtures/amd/deps/multi_line_no_indent/four.js
+++ b/tests/fixtures/amd/deps/multi_line_no_indent/four.js
@@ -1,0 +1,11 @@
+define([
+'path/to/a',
+'path/to/b',
+'path/to/c',
+'path/to/d'
+], function (
+a,
+b,
+c,
+d
+) { return { foo: 'bar' }; });

--- a/tests/fixtures/amd/deps/multi_line_no_indent/three.js
+++ b/tests/fixtures/amd/deps/multi_line_no_indent/three.js
@@ -1,0 +1,9 @@
+define([
+'path/to/a',
+'path/to/b',
+'path/to/c'
+], function (
+a,
+b,
+c
+) { return { foo: 'bar' }; });

--- a/tests/fixtures/amd/deps/multi_line_no_indent/two.js
+++ b/tests/fixtures/amd/deps/multi_line_no_indent/two.js
@@ -1,0 +1,7 @@
+define([
+'path/to/a',
+'path/to/b'
+], function (
+a,
+b
+) { return { foo: 'bar' }; });

--- a/tests/fixtures/amd/deps/single_line_no_indent/four.js
+++ b/tests/fixtures/amd/deps/single_line_no_indent/four.js
@@ -1,0 +1,1 @@
+define(['path/to/a', 'path/to/b', 'path/to/c', 'path/to/d'], function (a, b, c, d) { return { foo: 'bar' }; });

--- a/tests/fixtures/amd/deps/single_line_no_indent/three.js
+++ b/tests/fixtures/amd/deps/single_line_no_indent/three.js
@@ -1,0 +1,1 @@
+define(['path/to/a', 'path/to/b', 'path/to/c'], function (a, b, c) { return { foo: 'bar' }; });

--- a/tests/fixtures/amd/deps/single_line_no_indent/two.js
+++ b/tests/fixtures/amd/deps/single_line_no_indent/two.js
@@ -1,0 +1,1 @@
+define(['path/to/a', 'path/to/b'], function (a, b) { return { foo: 'bar' }; });

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -41,6 +41,9 @@ function loadFixture(path) {
     "./amd/deps/single_line/two.js",
     "./amd/deps/single_line/three.js",
     "./amd/deps/single_line/four.js",
+    "./amd/deps/single_line_no_indent/two.js",
+    "./amd/deps/single_line_no_indent/three.js",
+    "./amd/deps/single_line_no_indent/four.js",
     "./amd/deps/multi_line/one.js",
     "./amd/deps/multi_line/two.js",
     "./amd/deps/multi_line/three.js",
@@ -53,6 +56,9 @@ function loadFixture(path) {
     "./amd/deps/multi_line_names/two.js",
     "./amd/deps/multi_line_names/three.js",
     "./amd/deps/multi_line_names/four.js",
+    "./amd/deps/multi_line_no_indent/two.js",
+    "./amd/deps/multi_line_no_indent/three.js",
+    "./amd/deps/multi_line_no_indent/four.js",
 
     // Always Invalid
     "./EMPTY_DEFINE",

--- a/tests/lib/rules/one-dependency-per-line.js
+++ b/tests/lib/rules/one-dependency-per-line.js
@@ -186,47 +186,114 @@ var NEVER_NAMES_ERROR = {
         {
             code: fixtures.amd.deps.single_line.two,
             options: [{}],
-            errors: [ ALWAYS_PATHS_ERROR, ALWAYS_NAMES_ERROR ]
+            errors: [ ALWAYS_PATHS_ERROR, ALWAYS_NAMES_ERROR ],
+            output: fixtures.amd.deps.multi_line.two
         },
         {
             code: fixtures.amd.deps.single_line.three,
             options: [{}],
-            errors: [ ALWAYS_PATHS_ERROR, ALWAYS_NAMES_ERROR ]
+            errors: [ ALWAYS_PATHS_ERROR, ALWAYS_NAMES_ERROR ],
+            output: fixtures.amd.deps.multi_line.three
         },
         {
             code: fixtures.amd.deps.single_line.four,
             options: [{}],
-            errors: [ ALWAYS_PATHS_ERROR, ALWAYS_NAMES_ERROR ]
+            errors: [ ALWAYS_PATHS_ERROR, ALWAYS_NAMES_ERROR ],
+            output: fixtures.amd.deps.multi_line.four
         },
         {
             code: fixtures.amd.deps.multi_line_names.two,
             options: [{}],
-            errors: [ ALWAYS_PATHS_ERROR ]
+            errors: [ ALWAYS_PATHS_ERROR ],
+            output: fixtures.amd.deps.multi_line.two
         },
         {
             code: fixtures.amd.deps.multi_line_names.three,
             options: [{}],
-            errors: [ ALWAYS_PATHS_ERROR ]
+            errors: [ ALWAYS_PATHS_ERROR ],
+            output: fixtures.amd.deps.multi_line.three
         },
         {
             code: fixtures.amd.deps.multi_line_names.four,
             options: [{}],
-            errors: [ ALWAYS_PATHS_ERROR ]
+            errors: [ ALWAYS_PATHS_ERROR ],
+            output: fixtures.amd.deps.multi_line.four
         },
         {
             code: fixtures.amd.deps.multi_line_paths.two,
             options: [{}],
-            errors: [ ALWAYS_NAMES_ERROR ]
+            errors: [ ALWAYS_NAMES_ERROR ],
+            output: fixtures.amd.deps.multi_line.two
         },
         {
             code: fixtures.amd.deps.multi_line_paths.three,
             options: [{}],
-            errors: [ ALWAYS_NAMES_ERROR ]
+            errors: [ ALWAYS_NAMES_ERROR ],
+            output: fixtures.amd.deps.multi_line.three
         },
         {
             code: fixtures.amd.deps.multi_line_paths.four,
             options: [{}],
-            errors: [ ALWAYS_NAMES_ERROR ]
+            errors: [ ALWAYS_NAMES_ERROR ],
+            output: fixtures.amd.deps.multi_line.four
+        },
+        {
+            code: fixtures.amd.deps.single_line_no_indent.two,
+            options: [{}],
+            errors: [ ALWAYS_PATHS_ERROR, ALWAYS_NAMES_ERROR ],
+            output: fixtures.amd.deps.multi_line_no_indent.two
+        },
+        {
+            code: fixtures.amd.deps.single_line_no_indent.three,
+            options: [{}],
+            errors: [ ALWAYS_PATHS_ERROR, ALWAYS_NAMES_ERROR ],
+            output: fixtures.amd.deps.multi_line_no_indent.three
+        },
+        {
+            code: fixtures.amd.deps.single_line_no_indent.four,
+            options: [{}],
+            errors: [ ALWAYS_PATHS_ERROR, ALWAYS_NAMES_ERROR ],
+            output: fixtures.amd.deps.multi_line_no_indent.four
+        },
+
+        // "always" for paths only
+        {
+            code: fixtures.amd.deps.single_line.two,
+            options: [{"names": "never"}],
+            errors: [ ALWAYS_PATHS_ERROR ],
+            output: fixtures.amd.deps.multi_line_paths.two
+        },
+        {
+            code: fixtures.amd.deps.single_line.three,
+            options: [{"names": "never"}],
+            errors: [ ALWAYS_PATHS_ERROR ],
+            output: fixtures.amd.deps.multi_line_paths.three
+        },
+        {
+            code: fixtures.amd.deps.single_line.four,
+            options: [{"names": "never"}],
+            errors: [ ALWAYS_PATHS_ERROR ],
+            output: fixtures.amd.deps.multi_line_paths.four
+        },
+
+        // "always" for names only
+        {
+            code: fixtures.amd.deps.single_line.two,
+            options: [{"paths": "never"}],
+            errors: [ ALWAYS_NAMES_ERROR ],
+            output: fixtures.amd.deps.multi_line_names.two
+        },
+        {
+            code: fixtures.amd.deps.single_line.three,
+            options: [{"paths": "never"}],
+            errors: [ ALWAYS_NAMES_ERROR ],
+            output: fixtures.amd.deps.multi_line_names.three
+        },
+        {
+            code: fixtures.amd.deps.single_line.four,
+            options: [{"paths": "never"}],
+            errors: [ ALWAYS_NAMES_ERROR ],
+            output: fixtures.amd.deps.multi_line_names.four
         },
 
         // "never" for both


### PR DESCRIPTION
Fixes #51.

I've enabled testing of fixer for all the 'always' rules defined in the `one-dependency-per-line` test, and it correctly fixes them. I've also tested it out on our codebase and it correctly fixed all instances where the `one-dependency-per-line` rule failed.

_Notes_
- Had to upgrade the underlying `eslint` version because the older version doesn't support passing of an object into `context.report`.
- Had to remove a couple of duplicate `.eslintrc` rules since the YAML reader being used by `eslint` was throwing a duplicate key error.
