### PR TITLE
Fix: Sort-amd-path rule should ignore some paths (fixes #63)

### DIFF
--- a/lib/rules/sort-amd-paths.js
+++ b/lib/rules/sort-amd-paths.js
@@ -50,6 +50,28 @@ module.exports = function (context) {
     }
 
     /**
+     * Determine if supplied `node` represents a function expression.
+     *
+     * @private
+     * @param  {ASTNode} node - node to test
+     * @return {Boolean} true if represents a function expression
+     */
+    function isFunctionExpression(node) {
+        return node.type === "FunctionExpression";
+    }
+
+    /**
+     * Retrieve the AMD callback function argument from the provided `node`.
+     *
+     * @private
+     * @param {ASTNode} node - node to check for a function expression argument
+     * @returns {ASTNode} callback function expression
+     */
+    function getAmdCallback(node) {
+        return node.arguments.filter(isFunctionExpression)[0];
+    }
+
+    /**
      * Determine if dependency string nodes of supplied `node` are in
      * alphabetical order
      *
@@ -60,9 +82,14 @@ module.exports = function (context) {
      */
     function isInAlphabeticalOrder(node) {
         var result = true,
-            dependencyStringNodes = util.getDependencyStringNodes(node);
-        if (dependencyStringNodes) {
-            result = isArrayEqualTo(dependencyStringNodes, dependencyStringNodes.slice().sort(sortAlphabetically));
+            dependencyStringNodes = util.getDependencyStringNodes(node),
+            dependencyStringNodesToCheck = dependencyStringNodes,
+            callbackParams = getAmdCallback(node).params;
+        if (dependencyStringNodes.length > callbackParams.length) {
+            dependencyStringNodesToCheck = dependencyStringNodes.slice(0, callbackParams.length);
+        }
+        if (dependencyStringNodesToCheck) {
+            result = isArrayEqualTo(dependencyStringNodesToCheck, dependencyStringNodesToCheck.slice().sort(sortAlphabetically));
         }
         return result;
     }

--- a/tests/fixtures/ALPHABETICAL_PATHS_IGNORED_PATHS.js
+++ b/tests/fixtures/ALPHABETICAL_PATHS_IGNORED_PATHS.js
@@ -1,0 +1,10 @@
+define([
+    'aaa/bbb/xxx',
+    'aaa/bbb/yyy',
+    'aaa/bbb/zzz',
+    // following lines should be ignored
+    'aaa/bbb/aaa',
+    'aaa/bbb/bbb'
+], function (xxx, yyy, zzz) {
+    /* ... */
+});

--- a/tests/lib/rules/sort-amd-paths.js
+++ b/tests/lib/rules/sort-amd-paths.js
@@ -35,6 +35,7 @@ ruleTester.run("sort-amd-paths", rule, {
         fixtures.ALPHABETICAL_PATHS_MORE_PATHS_IN_ARRAY,
         fixtures.ALPHABETICAL_PATHS_BASENAME_CAPITAL,
         fixtures.ALPHABETICAL_PATHS_FULLPATH_INVALID,
+        fixtures.ALPHABETICAL_PATHS_IGNORED_PATHS,
 
         // valid `define` with { "compare": "dirname-basename" }
 


### PR DESCRIPTION
After merge, we should probably add `getAmdCallback` private function to utils API. It has the same implementation which is used in `amd-function-arity` rule.

But this "refactoring" imho doesn't belong to a bugfix commit. It should have a separate commit to master. 
