### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/lib/rules/amd-function-arity.js
+++ b/lib/rules/amd-function-arity.js
@@ -22,7 +22,8 @@ const isRequireCall = rjs.isRequireCall;
 const docs = {
     description: "Ensure AMD-style callbacks contain correct number of arguments",
     category: "Stylistic Choices",
-    recommended: false
+    recommended: false,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/amd-function-arity.md"
 };
 
 const schema = [

--- a/lib/rules/enforce-define.js
+++ b/lib/rules/enforce-define.js
@@ -20,7 +20,8 @@ const basename = path.basename;
 const docs = {
     description: "Disallow files that are not wrapped in a call to `define`",
     category: "Stylistic Choices",
-    recommended: false
+    recommended: false,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/enforce-define.md"
 };
 
 const schema = [

--- a/lib/rules/no-amd-define.js
+++ b/lib/rules/no-amd-define.js
@@ -16,7 +16,8 @@ const isAmdDefine = rjs.isAmdDefine;
 const docs = {
     description: "Disallow use of AMD (dependency array) form of `define`",
     category: "Stylistic Choices",
-    recommended: false
+    recommended: false,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-amd-define.md"
 };
 
 const schema = [];

--- a/lib/rules/no-assign-exports.js
+++ b/lib/rules/no-assign-exports.js
@@ -19,7 +19,8 @@ const isCommonJsWrapper = rjs.isCommonJsWrapper;
 const docs = {
     description: "Disallow assignment to `exports` when using Simplified CommonJS Wrapper",
     category: "Possible Errors",
-    recommended: true
+    recommended: true,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-assign-exports.md"
 };
 
 const schema = [];

--- a/lib/rules/no-assign-require.js
+++ b/lib/rules/no-assign-require.js
@@ -17,7 +17,8 @@ const isMemberExpr = ast.isMemberExpr;
 const docs = {
     description: "Disallow assignment to `require` or `window.require`",
     category: "Stylistic Choices",
-    recommended: false
+    recommended: false,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-assign-require.md"
 };
 
 const schema = [];

--- a/lib/rules/no-commonjs-exports.js
+++ b/lib/rules/no-commonjs-exports.js
@@ -20,7 +20,8 @@ const isCommonJsWrapper = rjs.isCommonJsWrapper;
 const docs = {
     description: "Disallow use of `exports` in a module definition when using Simplified CommonJS Wrapper",
     category: "Stylistic Choices",
-    recommended: true
+    recommended: true,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-commonjs-exports.md"
 };
 
 const schema = [];

--- a/lib/rules/no-commonjs-module-exports.js
+++ b/lib/rules/no-commonjs-module-exports.js
@@ -20,7 +20,8 @@ const isCommonJsWrapper = rjs.isCommonJsWrapper;
 const docs = {
     description: "Disallow use of `module.exports` in a module definition when using Simplified CommonJS Wrapper",
     category: "Stylistic Choices",
-    recommended: true
+    recommended: true,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-commonjs-module-exports.md"
 };
 
 const schema = [];

--- a/lib/rules/no-commonjs-return.js
+++ b/lib/rules/no-commonjs-return.js
@@ -19,7 +19,8 @@ const isCommonJsWrapper = rjs.isCommonJsWrapper;
 const docs = {
     description: "Disallow use of `return` statement in a module definition when",
     category: "Stylistic Choices",
-    recommended: true
+    recommended: true,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-commonjs-return.md"
 };
 
 const schema = [];

--- a/lib/rules/no-commonjs-wrapper.js
+++ b/lib/rules/no-commonjs-wrapper.js
@@ -16,7 +16,8 @@ const isCommonJsWrapper = rjs.isCommonJsWrapper;
 const docs = {
     description: "Disallow use of Simplified CommonJS Wrapper form of `define`",
     category: "Stylistic Choices",
-    recommended: true
+    recommended: true,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-commonjs-wrapper.md"
 };
 
 const schema = [];

--- a/lib/rules/no-conditional-require.js
+++ b/lib/rules/no-conditional-require.js
@@ -18,7 +18,8 @@ const isRequireCall = rjs.isRequireCall;
 const docs = {
     description: "Disallow use of conditional `require` calls",
     category: "Stylistic Choices",
-    recommended: true
+    recommended: true,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-conditional-require.md"
 };
 
 const schema = [];

--- a/lib/rules/no-dynamic-require.js
+++ b/lib/rules/no-dynamic-require.js
@@ -19,7 +19,8 @@ const isStringLiteralArray = ast.isStringLiteralArray;
 const docs = {
     description: "Disallow use of dynamically generated paths in a require call",
     category: "Stylistic Choices",
-    recommended: false
+    recommended: false,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-dynamic-require.md"
 };
 
 const schema = [];

--- a/lib/rules/no-function-define.js
+++ b/lib/rules/no-function-define.js
@@ -16,7 +16,8 @@ const isFunctionDefine = rjs.isFunctionDefine;
 const docs = {
     description: "Disallow use of simple function form of `define`",
     category: "Stylistic Choices",
-    recommended: false
+    recommended: false,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-function-define.md"
 };
 
 const schema = [];

--- a/lib/rules/no-invalid-define.js
+++ b/lib/rules/no-invalid-define.js
@@ -17,7 +17,8 @@ const isValidDefine = rjs.isValidDefine;
 const docs = {
     description: "Disallow invalid or undesired forms of `define`",
     category: "Possible Errors",
-    recommended: true
+    recommended: true,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-invalid-define.md"
 };
 
 const schema = [];

--- a/lib/rules/no-invalid-require.js
+++ b/lib/rules/no-invalid-require.js
@@ -17,7 +17,8 @@ const isValidRequire = rjs.isValidRequire;
 const docs = {
     description: "Disallow invalid or undesired forms of `require`",
     category: "Possible Errors",
-    recommended: true
+    recommended: true,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-invalid-require.md"
 };
 
 const schema = [];

--- a/lib/rules/no-js-extension.js
+++ b/lib/rules/no-js-extension.js
@@ -17,7 +17,8 @@ const getDependencyStringNodes = rjs.getDependencyStringNodes;
 const docs = {
     description: "Disallow `.js` extension in dependency paths",
     category: "Possible Errors",
-    recommended: true
+    recommended: true,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-js-extension.md"
 };
 
 const schema = [

--- a/lib/rules/no-multiple-define.js
+++ b/lib/rules/no-multiple-define.js
@@ -16,7 +16,8 @@ const isDefineCall = rjs.isDefineCall;
 const docs = {
     description: "Disallow multiple `define` calls in a single file",
     category: "Stylistic Choices",
-    recommended: false
+    recommended: false,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-multiple-define.md"
 };
 
 const schema = [];

--- a/lib/rules/no-named-define.js
+++ b/lib/rules/no-named-define.js
@@ -16,7 +16,8 @@ const isNamedDefine = rjs.isNamedDefine;
 const docs = {
     description: "Disallow use of named module form of `define`",
     category: "Stylistic Choices",
-    recommended: false
+    recommended: false,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-named-define.md"
 };
 
 const schema = [];

--- a/lib/rules/no-object-define.js
+++ b/lib/rules/no-object-define.js
@@ -16,7 +16,8 @@ const isObjectDefine = rjs.isObjectDefine;
 const docs = {
     description: "Disallow use of Simple Name/Value Pairs form of `define`",
     category: "Stylistic Choices",
-    recommended: false
+    recommended: false,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-object-define.md"
 };
 
 const schema = [];

--- a/lib/rules/no-require-tourl.js
+++ b/lib/rules/no-require-tourl.js
@@ -19,7 +19,8 @@ const isRequireIdentifier = rjs.isRequireIdentifier;
 const docs = {
     description: "Disallow use of `require.toUrl` and `require.nameToUrl`",
     category: "Stylistic Choices",
-    recommended: false
+    recommended: false,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-require-tourl.md"
 };
 
 const schema = [];

--- a/lib/rules/one-dependency-per-line.js
+++ b/lib/rules/one-dependency-per-line.js
@@ -20,7 +20,8 @@ const isFunctionExpr = ast.isFunctionExpr;
 const docs = {
     description: "Require or disallow one dependency per line",
     category: "Stylistic Choices",
-    recommended: false
+    recommended: false,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/one-dependency-per-line.md"
 };
 
 const schema = [

--- a/lib/rules/sort-amd-paths.js
+++ b/lib/rules/sort-amd-paths.js
@@ -20,7 +20,8 @@ const getDependencyStringNodes = rjs.getDependencyStringNodes;
 const docs = {
     description: "Ensure that required paths are ordered alphabetically",
     category: "Stylistic Choices",
-    recommended: false
+    recommended: false,
+    url: "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/sort-amd-paths.md"
 };
 
 const schema = [


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.