### PR TITLE
Fix: Support ArrowFunctionExpression in one-dependency-per-line

### DIFF
--- a/lib/rules/one-dependency-per-line.js
+++ b/lib/rules/one-dependency-per-line.js
@@ -86,7 +86,7 @@ const isAlways      = (val) => val === "always";
 const isNever       = (val) => val === "never";
 
 const indentation = (node) => {
-    const statement = node.body.body[0];
+    const statement = node.type === "ArrowFunctionExpression" ? node.body : node.body.body[0];
     return statement && line(node) !== line(statement) ? column(statement) : 0;
 };
 

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -941,3 +941,7 @@ define({
     b: 'bar'
 });
 `;
+
+exports.DEFINE_WITH_ARROW_FUNCTION = `
+define('underscore', [], () => window._);
+`;

--- a/tests/lib/rules/one-dependency-per-line.js
+++ b/tests/lib/rules/one-dependency-per-line.js
@@ -50,6 +50,11 @@ testRule("one-dependency-per-line", rule, {
         fixtures.BAD_REQUIRE_STRING_DEP,
         fixtures.BAD_REQUIREJS_STRING_DEP,
 
+        {
+            code: fixtures.DEFINE_WITH_ARROW_FUNCTION,
+            parserOptions: { ecmaVersion: 6 }
+        },
+
         // zero deps should never trigger warning, regardless of options
         {
             code: fixtures.AMD_DEPS_NONE,


### PR DESCRIPTION
Resolves #106