### PR TITLE
Add new rule: no-restricted-amd

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ These rules relate to style guidelines, and are therefore quite subjective:
 |        | :wrench: | [one-dependency-per-line](docs/rules/one-dependency-per-line.md) | Enforce line-break rules for AMD dependencies |
 |        |          | [amd-function-arity](docs/rules/amd-function-arity.md) | Ensure AMD callbacks have correct number of parameters |
 |        |          | [sort-amd-paths](docs/rules/sort-amd-paths.md) | Ensure that required paths are in alphabetical order |
+|        |          | [no-restricted-amd-modules](docs/rules/no-restricted-amd-modules.md) | Disallow specific amd modules |
 
 ### Don't see the rule you're looking for?
 

--- a/docs/rules/no-restricted-amd-modules.md
+++ b/docs/rules/no-restricted-amd-modules.md
@@ -1,0 +1,102 @@
+# Disallow specific amd modules (no-restricted-amd-modules)
+
+Disallowing usage of specific AMD modules can be useful if you want to limit the available methods a developer can use. For example, you can block usage of the `module-foo` module if you want to force using a more performant module named `module-bar`.
+
+## Rule Details
+
+This rule allows you to specify modules that you don’t want to use in your application.
+
+## Options
+
+The rule takes one or more strings as options: the names of restricted modules.
+
+```json
+"no-restricted-amd-modules": ["error", "module-foo", "module-bar"]
+```
+
+It can also take an object with lists of `paths` and gitignore-style `patterns` strings.
+
+```json
+"no-restricted-amd-modules": ["error", {
+    "paths": ["module-foo", "module-bar"],
+    "patterns": ["module-foo/private/*", "module-bar/*", "!module-bar/good"]
+}]
+```
+
+You may also specify a custom message for any paths you want to restrict as follows:
+
+```json
+"no-restricted-amd-modules": ["error",
+  {
+    "name": "module-foo1",
+    "message": "Please use module-foo2 instead."
+  },
+ {
+    "name": "module-bar2",
+    "message": "Please use module-bar2 instead."
+  }
+]
+```
+
+or like this:
+
+```json
+"no-restricted-amd-modules": ["error", {
+  "paths": [{
+    "name": "module-foo",
+    "message": "Please use module-bar instead."
+  }]
+}]
+```
+
+The custom message will be appended to the default error message. Please note that you may not specify custom error messages for restricted patterns as a particular module may match more than one pattern.
+
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-restricted-amd-modules: ["error", "foo", "bar"]*/
+
+define(['foo', 'bar', 'baz'], function () {
+    /* ... */
+});
+```
+
+```js
+/*eslint no-restricted-amd-modules: ["error", {"paths": ["foo/bar"] }]*/
+
+define(['foo/bar', 'baz'], function () {
+    /* ... */
+});
+```
+
+```js
+/*eslint no-restricted-amd-modules: ["error", { "patterns": ["foo/bar/*"] }]*/
+
+define(['foo/bar/baz'], function () {
+    /* ... */
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-restricted-amd-modules: ["error", "baz"]*/
+
+define(['foo', 'bar'], function () {
+    /* ... */
+});
+```
+
+```js
+/*eslint no-restricted-amd-modules: ["error", {
+    "paths": ["foo"],
+    "patterns": ["baz/*", "!baz/pick"]
+}]*/
+
+define(['bar', 'baz/pick'], function () {
+    /* ... */
+});
+```

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ module.exports = {
         "enforce-define": require("./lib/rules/enforce-define"),
         "one-dependency-per-line": require("./lib/rules/one-dependency-per-line"),
         "amd-function-arity": require("./lib/rules/amd-function-arity"),
-        "sort-amd-paths": require("./lib/rules/sort-amd-paths")
+        "sort-amd-paths": require("./lib/rules/sort-amd-paths"),
+        "no-restricted-amd-modules": require("./lib/rules/no-restricted-amd-modules")
     },
     configs: {
         recommended: {

--- a/lib/rules/no-restricted-amd-modules.js
+++ b/lib/rules/no-restricted-amd-modules.js
@@ -1,0 +1,184 @@
+/**
+ * @file    Rule to disallow specified modules when loaded by `define`
+ * @author  Stefan Buck
+ */
+
+"use strict";
+
+const ignore = require("ignore");
+const rjs = require("../utils/rjs");
+
+const isAmdDefine = rjs.isAmdDefine;
+const isAmdRequire = rjs.isAmdRequire;
+const getDependencyStringNodes = rjs.getDependencyStringNodes;
+
+// -----------------------------------------------------------------------------
+// Configuration
+// -----------------------------------------------------------------------------
+
+const docs = {
+    description: "Disallow specified modules when loaded by `define`",
+    category: "Stylistic Choices",
+    recommended: false,
+    url:
+        "https://github.com/cvisco/eslint-plugin-requirejs/blob/master/docs/rules/no-restricted-amd-modules.md"
+};
+
+const arrayOfStrings = {
+    type: "array",
+    items: { type: "string" },
+    uniqueItems: true
+};
+
+const arrayOfStringsOrObjects = {
+    type: "array",
+    items: {
+        anyOf: [
+            { type: "string" },
+            {
+                type: "object",
+                properties: {
+                    name: { type: "string" },
+                    message: {
+                        type: "string",
+                        minLength: 1
+                    }
+                },
+                additionalProperties: false,
+                required: ["name"]
+            }
+        ]
+    },
+    uniqueItems: true
+};
+
+const schema = {
+    anyOf: [
+        arrayOfStringsOrObjects,
+        {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    paths: arrayOfStringsOrObjects,
+                    patterns: arrayOfStrings
+                },
+                additionalProperties: false
+            },
+            additionalItems: false
+        }
+    ]
+};
+
+const DEFAULT_MESSAGE_TEMPLATE =
+    "'{{moduleName}}' module is restricted from being used.";
+const CUSTOM_MESSAGE_TEMPLATE =
+    "'{{moduleName}}' module is restricted from being used. {{customMessage}}";
+
+// -----------------------------------------------------------------------------
+// Rule Definition
+// -----------------------------------------------------------------------------
+
+function create(context) {
+    const options = Array.isArray(context.options) ? context.options : [];
+    const isPathAndPatternsObject =
+        typeof options[0] === "object" &&
+        (Object.prototype.hasOwnProperty.call(options[0], "paths") ||
+            Object.prototype.hasOwnProperty.call(options[0], "patterns"));
+
+    const restrictedPaths =
+        (isPathAndPatternsObject ? options[0].paths : options) || [];
+    const restrictedPatterns =
+        (isPathAndPatternsObject ? options[0].patterns : []) || [];
+
+    const restrictedPathMessages = restrictedPaths.reduce(
+        (memo, importName) => {
+            if (typeof importName === "string") {
+                memo[importName] = null;
+            } else {
+                memo[importName.name] = importName.message;
+            }
+            return memo;
+        },
+        {}
+    );
+
+    // if no modules are restricted we don"t need to check
+    if (
+        Object.keys(restrictedPaths).length === 0 &&
+        restrictedPatterns.length === 0
+    ) {
+        return {};
+    }
+
+    const ig = ignore().add(restrictedPatterns);
+
+    /**
+     * Report a restricted path.
+     * @param {node} node representing the restricted path reference
+     * @returns {void}
+     * @private
+     */
+    function reportPath(node) {
+        const moduleName = node.value.trim();
+        const customMessage = restrictedPathMessages[moduleName];
+        const message = customMessage
+            ? CUSTOM_MESSAGE_TEMPLATE
+            : DEFAULT_MESSAGE_TEMPLATE;
+
+        context.report({
+            node,
+            message,
+            data: {
+                moduleName,
+                customMessage
+            }
+        });
+    }
+
+    /**
+     * Check if the given name is a restricted path name
+     * @param {string} name name of a variable
+     * @returns {boolean} whether the variable is a restricted path or not
+     * @private
+     */
+    function isRestrictedPath(name) {
+        return Object.prototype.hasOwnProperty.call(
+            restrictedPathMessages,
+            name
+        );
+    }
+
+    return {
+        CallExpression(node) {
+            if (!isAmdDefine(node) && !isAmdRequire(node)) return;
+
+            const paths = getDependencyStringNodes(node);
+
+            for (let i = 0; i < paths.length; i++) {
+                const nodeCurrent = paths[i];
+                const moduleName = nodeCurrent.value.trim();
+
+                // check if argument value is in restricted modules array
+                if (isRestrictedPath(moduleName)) {
+                    reportPath(nodeCurrent);
+                }
+
+                if (restrictedPatterns.length > 0 && ig.ignores(moduleName)) {
+                    context.report({
+                        node,
+                        message:
+                            "'{{moduleName}}' module is restricted from being used by a pattern.",
+                        data: { moduleName }
+                    });
+                    break;
+                }
+            }
+        }
+    };
+}
+
+module.exports = {
+    meta: { docs, schema },
+    create
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -702,6 +702,12 @@
           "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
           "dev": true
         },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
         "js-yaml": {
           "version": "3.11.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
@@ -773,6 +779,14 @@
         "object-assign": "^4.0.1",
         "resolve": "^1.1.7",
         "semver": "5.2.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        }
       }
     },
     "espree": {
@@ -1121,10 +1135,9 @@
       }
     },
     "ignore": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.3.tgz",
-      "integrity": "sha1-nokMBlJRkRWulCfaR1Fr1U0daZk=",
-      "dev": true
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.5.tgz",
+      "integrity": "sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA=="
     },
     "imurmurhash": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "major": "node makefile.js major",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "mocha": "mocha"
+  },
+  "dependencies": {
+    "ignore": "5.0.5"
   }
 }

--- a/tests/lib/rules/no-restricted-amd-modules.js
+++ b/tests/lib/rules/no-restricted-amd-modules.js
@@ -1,0 +1,155 @@
+/**
+ * @file    Tests for `no-restricted-amd-modules` rule
+ * @author  Stefan Buck
+ */
+
+"use strict";
+
+const testRule = require("../../rule-tester");
+const fixtures = require("../../fixtures");
+const rule = require("../../../lib/rules/no-restricted-amd-modules");
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+const errorMsg = expected => ({
+    message: `'${expected}' module is restricted from being used.`,
+    type: "Literal"
+});
+
+testRule("no-restricted-amd-modules", rule, {
+    valid: [
+        { code: fixtures.AMD_DEFINE, options: ["foo"] },
+        { code: fixtures.FUNCTION_DEFINE, options: ["foo", "bar"] },
+        { code: fixtures.AMD_DEFINE, options: ["foo", "bar"] },
+        fixtures.AMD_DEFINE,
+        {
+            code: fixtures.AMD_DEFINE_WITH_FOO_PLUGIN_AND_JS_EXT,
+            options: ["foo"]
+        },
+        { code: fixtures.AMD_DEFINE_WITH_JS_EXT, options: ["foo"] },
+        { code: fixtures.AMD_EMPTY_DEFINE, options: ["foo"] },
+        { code: fixtures.AMD_DEFINE, options: ["path/to"] },
+        {
+            code: fixtures.AMD_DEFINE,
+            options: [{ paths: ["path", "to", "a"] }]
+        },
+        {
+            code: fixtures.AMD_DEFINE,
+            options: [{ patterns: ["path/to/c*"] }]
+        },
+        {
+            code: fixtures.AMD_DEFINE,
+            options: [{ paths: ["path/to"], patterns: ["path/to/c*"] }]
+        },
+        {
+            code: fixtures.AMD_DEFINE_WITH_JS_EXT,
+            options: [
+                { paths: ["path/to"], patterns: ["path/to/*", "!path/to/a.js"] }
+            ]
+        }
+    ],
+    invalid: [
+        {
+            code: fixtures.AMD_DEFINE,
+            options: ["path/to/a"],
+            errors: [errorMsg("path/to/a")]
+        },
+        {
+            code: fixtures.AMD_DEFINE,
+            options: ["path/to/b"],
+            errors: [errorMsg("path/to/b")]
+        },
+        {
+            code: fixtures.AMD_DEFINE_WITH_JS_EXT,
+            options: [{ paths: ["path/to/a.js"] }],
+            errors: [errorMsg("path/to/a.js")]
+        },
+        {
+            code: fixtures.AMD_DEFINE_WITH_FOO_PLUGIN_AND_JS_EXT,
+            options: [{ paths: ["foo!aaa/bbb/ccc.js"] }],
+            errors: [errorMsg("foo!aaa/bbb/ccc.js")]
+        },
+        {
+            code: fixtures.AMD_DEFINE_WITH_FOO_PLUGIN_AND_JS_EXT,
+            options: [{ patterns: ["*!aaa/bbb/ccc.js"] }],
+            errors: [
+                {
+                    message:
+                        "'foo!aaa/bbb/ccc.js' module is restricted from being used by a pattern.",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: fixtures.AMD_DEFINE,
+            options: [{ patterns: ["path/to/*"] }],
+            errors: [
+                {
+                    message:
+                        "'path/to/a' module is restricted from being used by a pattern.",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: fixtures.AMD_DEFINE,
+            options: [{ paths: ["path/to/*"], patterns: ["path/to"] }],
+            errors: [
+                {
+                    message:
+                        "'path/to/a' module is restricted from being used by a pattern.",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: fixtures.AMD_DEFINE,
+            options: [
+                { patterns: ["path/to/*", "!path/to/c"], paths: ["path/to"] }
+            ],
+            errors: [
+                {
+                    message:
+                        "'path/to/a' module is restricted from being used by a pattern.",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: fixtures.AMD_DEFINE,
+            options: [
+                {
+                    name: "path/to/a",
+                    message: "Please use 'path/to/c' module instead."
+                }
+            ],
+            errors: [
+                {
+                    message:
+                        "'path/to/a' module is restricted from being used. Please use 'path/to/c' module instead.",
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: fixtures.AMD_DEFINE,
+            options: [
+                "path/to",
+                {
+                    name: "path/to/a",
+                    message: "Please use 'path/to/c' module instead."
+                },
+                "path/to/d"
+            ],
+            errors: [
+                {
+                    message:
+                        "'path/to/a' module is restricted from being used. Please use 'path/to/c' module instead.",
+                    type: "Literal"
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
> Fixes #109. The implementation as well as the test cases are heavily inspired by [no-restricted-modules](https://github.com/eslint/eslint/blob/master/lib/rules/no-restricted-modules.js).

This rule disallow specified modules from being used via `define(...)`. The modules to disallow must be configurable, such as:

```js
/*eslint no-restricted-amd: ["error", "foo", "bar"]*/

define(['foo', 'baz'], function (foo, baz) {
    /* ... */
});
```

This would warn on `foo`. 

More advanced examples are available in the documentation. 
