### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ node_js:
     - 6
     - 8
     - 10
+    - 12
+    - 14
+    
+arch:
+    - amd64
+    - ppc64le
 
 after_success:
     - "npm run coveralls"


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.